### PR TITLE
fix `go-license` signature compatibility

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,7 @@ name = "licverify"
 path = "src/main.rs"
 
 [dependencies]
-rsa = { version = "0.9", features = ["std"] }
-sha2 = "0.10"
+rsa = { version = "0.9", features = ["std", "sha2"] }
 signature = "2.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"


### PR DESCRIPTION
- add missing signature prefix (don't use `new_unprefixed`)
- hash only once (`digest` is called in `verify`)